### PR TITLE
Fix a Debug Build Error

### DIFF
--- a/src/Runnables/main.cpp
+++ b/src/Runnables/main.cpp
@@ -230,7 +230,7 @@ int main(int argc, char *argv[]) {
     auto outputType         = parser.value("outputType").toUpper();
 
 #ifndef NDEBUG 
-    qDebug() << endl;
+    qDebug() << Qt::endl;
     qDebug() << "\tInputFile :"   << inputFile;
     qDebug() << "\tOutputDir :"   << outputDir;
     qDebug() << "\tAlgorithm :"   << algorithm;


### PR DESCRIPTION
Fix a debug build error w.r.t. Qt debug messages, i.e., endl becomes Qt::ends. The namespace is required in this particular case.