### PR TITLE
Add Debug Build to CMake Workflow for all OS

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -29,7 +29,7 @@ jobs:
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        build_type: [Release]
+        build_type: [Release, Debug]
         c_compiler: [gcc, clang, cl]
         include:
           - os: windows-latest

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -12,7 +12,6 @@ on:
 
 env:
   QT_VERSION:     "6.2.0"
-  BUILD_TYPE:      Release
 
 jobs:
   build:


### PR DESCRIPTION
In this PR, we add the build type `Debug` for OSs to the CI.