### PR TITLE
Googletest framework branch changed from master to main

### DIFF
--- a/cmake/ExternalProjectConfiguration.cmake
+++ b/cmake/ExternalProjectConfiguration.cmake
@@ -78,7 +78,7 @@ if ( EGOA_DOWNLOAD_GOOGLE_TEST_FRAMEWORK )
     ExternalProject_Add ( GoogleTestFramework
         GIT_REPOSITORY  https://github.com/google/googletest.git
         SOURCE_DIR      "${PROJECT_INCLUDE_DIR}/external/GoogleTestFramework"
-        GIT_TAG         master
+        GIT_TAG         main
         GIT_SHALLOW     1
     )
 endif ( EGOA_DOWNLOAD_GOOGLE_TEST_FRAMEWORK )


### PR DESCRIPTION
The Googletest framework branch changed from master to main. For more information, see https://github.com/google/googletest.git.

Changes to be committed:
	modified:   cmake/ExternalProjectConfiguration.cmake