### PR TITLE
Add Root Run for CMake to cmake-multi-platform.yml

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -171,7 +171,10 @@ jobs:
         -S ${{ github.workspace }}
 
     - name: Build
+      if: startsWith(matrix.os, 'ubuntu-')
       # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
+      run: sudo cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
+      if: ! startsWith(matrix.os, 'ubuntu-')
       run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
 
     - name: Test


### PR DESCRIPTION
We add sudo to the cmake build run to solve the permission denied issue with gmock and other frameworks that need write access for /usr/local/include.