### PR TITLE
Google Test Framework Online Version: Switch Branch from Master to Main

### DIFF
--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -1,4 +1,4 @@
-# This file is from https://github.com/google/googletest/tree/master/googletest
+# This file is from https://github.com/google/googletest/tree/main/googletest
 cmake_minimum_required(VERSION 2.8.2)
 
 project(googletest-download NONE)
@@ -6,7 +6,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           master
+  GIT_TAG           main
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""

--- a/cmake/FindGoogleTestFrameworkOnlineVersion.cmake
+++ b/cmake/FindGoogleTestFrameworkOnlineVersion.cmake
@@ -1,7 +1,7 @@
 # FindGoogleTestFrameworkOnlineVersion.cmake
 # 
 #   Created on: Jan 30, 2019
-#       Source: https://github.com/google/googletest/tree/master/googletest 
+#       Source: https://github.com/google/googletest/tree/main/googletest 
 # 
 # Requirements      
 #   * CMake 2.8. or later due to the use of ExternalProject_Add(). 


### PR DESCRIPTION
For more information, see https://github.com/google/googletest/tree/main/googletest. It changed between 2019 and 2023. Most companies renamed their `master` branch to `main`.