### PR TITLE
Change BinaryHeap Iterator from std::input_iterator_tag to std::forward_iterator_tag

### DIFF
--- a/include/DataStructures/Container/Queues/BinaryHeap.hpp
+++ b/include/DataStructures/Container/Queues/BinaryHeap.hpp
@@ -554,7 +554,7 @@ class BinaryHeap {
                 Types::largeNumber end_;                /**< End */
                 std::vector<TElement> const * vector_;  /**< Vector of elements */
             public:
-                using iterator_category = std::input_iterator_tag;  /**< Iterator category type */
+                using iterator_category = std::forward_iterator_tag;/**< Iterator category type */
                 using value_type        = TElement;                 /**< Value type */
                 using difference_type   = Types::difference;        /**< Difference type */
                 using pointer           = const TElement*;          /**< Element pointer type */


### PR DESCRIPTION
In this PR, we change the iterator due to the error we get while running the `Bucket` data structure tests that asks for a forward_iterator and cannot convert from `std::input_iterator` to `std::forward_iterator`.