### PR TITLE
Apply MSVC Flag `bigobj` only to Debug Mode

### DIFF
--- a/cmake/CompilerConfiguration.cmake
+++ b/cmake/CompilerConfiguration.cmake
@@ -46,8 +46,13 @@ set(PEDANTIC_FLAGS "-pedantic")
 # Microsoft Visual Studio ##########################################
 ####################################################################
 if(MSVC)
-    # D:\a\egoa\egoa\tests\DataStructures\Graphs\TestGraph.cpp : fatal  error C1128: number of sections exceeded object file format limit: compile with /bigobj [D:\a\egoa\egoa\build\tests\TestGraph.vcxproj]
-    add_definitions(/MP /DNOMINMAX /bigobj)
+    add_definitions(/MP /DNOMINMAX)
+    if(CMAKE_BUILD_TYPE MATCHES "Debug")
+        # D:\a\egoa\egoa\tests\DataStructures\Graphs\TestGraph.cpp : fatal
+        # error C1128: number of sections exceeded object file format limit:
+        # compile with /bigobj [D:\a\egoa\egoa\build\tests\TestGraph.vcxproj]
+        add_definitions(/bigobj)
+    endif()
     set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} /Debug:fastlink")
     # https://docs.microsoft.com/en-us/cpp/build/reference/wx-treat-linker-warnings-as-errors?view=vs-2019
     set(EGOA_WARNINGS_AS_ERRORS_FLAG "/WX")


### PR DESCRIPTION
This problem occurs in MSVC Debug mode only. Thus, we only add the required in debug mode only.