### PR TITLE
Add `Clang-Tidy` to the Project

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -72,6 +72,11 @@ jobs:
         cache-key-prefix: ${{ runner.os }}-Qt-Cache-${{ env.QT_VERSION }}
         dir: ${{ github.workspace }}/Qt
 
+    - name: Install LLVM for Clang-Tidy (MacOS)
+      if: startsWith(matrix.os,'macos-')
+      run: |
+        brew install llvm
+
     # - name: Install correct version of mingw
     #   uses: crazy-max/ghaction-chocolatey@v1
     #   with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,6 +230,13 @@ if ( Qt6_FOUND )
     target_compile_definitions ( EGOA PUBLIC QT6_AVAILABLE )
 endif ( Qt6_FOUND )
 
+# clang-tidy found
+if ( CLANG_TIDY_PROG )
+    message ( STATUS "${MY_SPACE}clang-tidy:\t\t\t\tis enabled" )
+    # set CXX_CLANG_TIDY property after defining the target
+    # set_target_properties(EGOA PROPERTIES CXX_CLANG_TIDY "${CMAKE_CXX_CLANG_TIDY}")
+endif ( CLANG_TIDY_PROG )
+
 # OpenMP found
 if ( OPENMP_FOUND )
     message ( STATUS "${MY_SPACE}OpenMP:\t\t\t\tadd libraries of OpenMP" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,9 @@ if ( EGOA_ENABLE_BOOST )
     include ( Boost )
 endif ( EGOA_ENABLE_BOOST )
 
+# Search for clang-tidy
+find_package ( ClangTidy )
+
 # Google tests
 if ( EGOA_ENABLE_TESTS )
     include ( CTest )

--- a/cmake/FindClangTidy.cmake
+++ b/cmake/FindClangTidy.cmake
@@ -1,0 +1,26 @@
+# FindClangTidy.cmake
+# 
+#   Created on: Dec 27, 2023
+#       Author: Franziska Wegner
+# 
+# This file enables clang tidy for the project.
+# 
+
+
+# Search for clang-tidy
+find_program(CLANG_TIDY_PROG 
+    HINTS "/opt/homebrew/opt/llvm/bin/"
+    NAMES "clang-tidy" REQUIRED)
+# Setup clang-tidy command with executable and options, see https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_CLANG_TIDY.html.
+# Disable all default checks (-*) and only enable checks that advocate the use of modern C++ language constructs with (modernize-*).
+set(CMAKE_CXX_CLANG_TIDY
+    "${CLANG_TIDY_PROG}"
+    "-checks=-*,modernize-*"
+    # -format-style='file';
+    # -header-filter=${CMAKE_CURRENT_SOURCE_DIR};
+    # -header-filter=.;
+    # -warnings-as-errors=*;
+    )
+
+# set CXX_CLANG_TIDY property after defining the target
+# set_target_properties(EGOA PROPERTIES CXX_CLANG_TIDY "${CMAKE_CXX_CLANG_TIDY}")

--- a/cmake/FindClangTidy.cmake
+++ b/cmake/FindClangTidy.cmake
@@ -10,7 +10,10 @@
 # Search for clang-tidy
 find_program(CLANG_TIDY_PROG 
     HINTS "/opt/homebrew/opt/llvm/bin/"
-    NAMES "clang-tidy" REQUIRED)
+          "/usr/local/opt/llvm/bin/"
+    NAMES "clang-tidy"
+    REQUIRED
+    )
 # Setup clang-tidy command with executable and options, see https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_CLANG_TIDY.html.
 # Disable all default checks (-*) and only enable checks that advocate the use of modern C++ language constructs with (modernize-*).
 set(CMAKE_CXX_CLANG_TIDY


### PR DESCRIPTION
This PR enables `clang-tidy` in the main CMake file [5]. Clang-tidy will help to enable developer guidelines such as [1,2]. The C++ Core Guidelines checkers are more a MSVC tool, which is not usable in a multi-platform development framework. A documentation for `clang-tidy` can be found in [4].


[1] https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines
[2] https://developers.google.com/style/
[3] https://github.com/MicrosoftDocs/cpp-docs/blob/main/docs/code-quality/using-the-cpp-core-guidelines-checkers.md
[4] https://clang.llvm.org/extra/clang-tidy/
[5] https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_CLANG_TIDY.html