### PR TITLE
Update C/C++ Linter Workflow

### DIFF
--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -126,7 +126,7 @@ jobs:
           # in a pull request's thread. Set it to false to disable the comment.
           # Set it to true to post a new comment (and delete the old comment).
           thread-comments: ${{ github.event_name == 'pull_request' && 'update' }}
-          ignore: "external|Qt"
+          ignore: "external|Qt|build/CMakeFiles"
 
       - name: Fail fast?!
         if: steps.linter.outputs.checks-failed > 0

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -20,6 +20,12 @@ concurrency:
 env:
   QT_VERSION:     "6.2.0"
 
+permissions:
+  contents: read
+  packages: read
+  # To report GitHub Actions status checks
+  statuses: write
+
 jobs:
   cpp-linter:
 

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -112,7 +112,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           style: "file" #llvm
-          tidy-checks: boost-*,bugprone-*,performance-*,readability-*,portability-*,modernize-*,clang-analyzer-*,cppcoreguidelines-*
+          tidy-checks: "boost-*,bugprone-*,performance-*,readability-*,portability-*,modernize-*,clang-analyzer-*,cppcoreguidelines-*"
           files-changed-only: false
           lines-changed-only: false
           no-lgtm: false

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -111,7 +111,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          style: llvm #file
+          style: "file" #llvm
           tidy-checks: boost-*,bugprone-*,performance-*,readability-*,portability-*,modernize-*,clang-analyzer-*,cppcoreguidelines-*
           files-changed-only: false
           lines-changed-only: false

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -120,7 +120,7 @@ jobs:
           # in a pull request's thread. Set it to false to disable the comment.
           # Set it to true to post a new comment (and delete the old comment).
           thread-comments: ${{ github.event_name == 'pull_request' && 'update' }}
-          ignore: external
+          ignore: "external|Qt"
 
       - name: Fail fast?!
         if: steps.linter.outputs.checks-failed > 0


### PR DESCRIPTION
This PR updates the C/C++ Linter workflow at `.github/workflows/cpp-linter.yml`. The style is changed from `llvm` to `file` and the action ignores now also `Qt/Qt` and `build/CMakeFiles` folder that are out of the repositories changing reach.