### PR TITLE
Add Pre-Commit Hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-ast
+      - id: check-case-conflict
+      - id: check-json
+      - id: check-symlinks
+      - id: check-xml
+      - id: check-yaml
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: no-commit-to-branch
+        args: [--branch, staging, --branch, main]
+      - id: pretty-format-json
+        args: [--autofix, --indent, 4]
+      - id: requirements-txt-fixer
+      - id: trailing-whitespace


### PR DESCRIPTION
This PR adds a set of precommit hooks to the framework to validate commits. We add the `.pre-commit-config.yaml` to the main directory for that.