### PR TITLE
Add Black for `python` Formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,7 @@ repos:
         args: [--autofix, --indent, 4]
       - id: requirements-txt-fixer
       - id: trailing-whitespace
+  - repo: https://github.com/psf/black
+    rev: 22.10.0
+    hooks:
+    -   id: black


### PR DESCRIPTION
This PR adds black as part of the precommit actions to `.pre-commit-config.yaml`. For more information see [1].

[1] https://pre-commit.com