### PR TITLE
Introduce Code Documentation Workflow Dependent on CMake Workflow

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -82,41 +82,6 @@ jobs:
     #   with:
     #     args: install mingw --version=8.1.0  -y
 
-    # Compared to Window and MacOS best option with stable ~2 min installation time.
-    - name: Install LaTeX (Linux)
-      if: startsWith(matrix.os,'ubuntu-')
-      run: |
-        sudo apt update --fix-missing
-        sudo apt upgrade
-        sudo apt update
-        sudo apt-get install texlive texlive-latex-recommended texlive-extra-utils texlive-latex-extra texlive-font-utils
-      shell: bash
-
-    # Takes too long > 13 min
-    # - name: Install LaTeX (MacOS)
-    #   if: startsWith(matrix.os,'macos-')
-    #   run: |
-    #     brew update
-    #     brew install --cask mactex;
-    #     echo "/Library/TeX/texbin/" >> $GITHUB_PATH
-    #   shell: bash
-
-    # Takes too long >> 25 min
-    # - name: Install LaTeX (Windows)
-    #   if: startsWith(matrix.os, 'windows-')
-    #   uses: teatimeguest/setup-texlive-action@v3
-    #   with:
-    #     packages: >-
-    #       scheme-medium
-    #       collection-latexextra
-    #       babel-dutch
-    #       cjk
-    #       bibtex
-
-    # For Doxygen installation use action from https://github.com/marketplace/actions/doxygen-install.
-    - name: doxygen-install
-      uses: ssciwr/doxygen-install@v1.2.0
-
     - name: Set reusable strings
       # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
       id: strings
@@ -279,30 +244,3 @@ jobs:
       uses: codecov/codecov-action@v3
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-    - name: Generate documentation
-      if: startsWith(matrix.os,'ubuntu-')
-      shell: sudo cmake -P {0}
-      run: |
-        execute_process(
-          COMMAND cmake --build build --target doc
-          RESULT_VARIABLE result
-        )
-        if (NOT result EQUAL 0)
-          message(FATAL_ERROR "Building documentation failed")
-        endif()
-
-    # See https://github.com/marketplace/actions/github-pages-action#%EF%B8%8F-deploy-to-external-repository-external_repository
-    # for more information on the parameters.
-    - name: Publish Documentation to Github Pages
-      uses: peaceiris/actions-gh-pages@v3
-      if: ${{ github.event_name == 'push' && startsWith(matrix.os,'ubuntu-') }}
-      with:
-         github_token: ${{ secrets.GITHUB_TOKEN }}
-         deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-         publish_dir: documentation/html
-         force_orphan: true
-         commit_message: ${{ github.event.head_commit.message }}
-         publish_branch: gh-pages
-         user_name: 'github-actions[bot]'
-         user_email: 'github-actions[bot]@users.noreply.github.com'

--- a/.github/workflows/code-documentation.yml
+++ b/.github/workflows/code-documentation.yml
@@ -1,0 +1,120 @@
+name: Code Documentation
+
+on:
+  workflow_run:
+    workflows: [ "CMake on multiple platforms" ]
+    branches: [ "main" ]
+    types: [ "completed" ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
+      fail-fast: false
+
+      # Set up a matrix to run the following 3 configurations:
+      # 1. <Windows, Release, latest MSVC compiler toolchain on the default runner image, default generator>
+      # 2. <Linux, Release, latest GCC compiler toolchain on the default runner image, default generator>
+      # 3. <Linux, Release, latest Clang compiler toolchain on the default runner image, default generator>
+      #
+      # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        build_type: [Release, Debug]
+        c_compiler: [gcc, clang, cl]
+        include:
+          - os: windows-latest
+            c_compiler: cl
+            cpp_compiler: cl
+          - os: ubuntu-latest
+            c_compiler: gcc
+            cpp_compiler: g++
+          - os: ubuntu-latest
+            c_compiler: clang
+            cpp_compiler: clang++
+          - os: macos-latest
+            c_compiler: gcc
+            cpp_compiler: g++
+          - os: macos-latest
+            c_compiler: clang
+            cpp_compiler: clang++
+        exclude:
+          - os: windows-latest
+            c_compiler: gcc
+          - os: windows-latest
+            c_compiler: clang
+          - os: ubuntu-latest
+            c_compiler: cl
+          - os: macos-latest
+            c_compiler: cl
+
+    steps:
+    - uses: actions/checkout@v3
+
+    # Compared to Window and MacOS best option with stable ~2 min installation time.
+    - name: Install LaTeX (Linux)
+      if: startsWith(matrix.os,'ubuntu-')
+      run: |
+        sudo apt update --fix-missing
+        sudo apt upgrade
+        sudo apt update
+        sudo apt-get install texlive texlive-latex-recommended texlive-extra-utils texlive-latex-extra texlive-font-utils
+      shell: bash
+
+    # Takes too long > 13 min
+    # - name: Install LaTeX (MacOS)
+    #   if: startsWith(matrix.os,'macos-')
+    #   run: |
+    #     brew update
+    #     brew install --cask mactex;
+    #     echo "/Library/TeX/texbin/" >> $GITHUB_PATH
+    #   shell: bash
+
+    # Takes too long >> 25 min
+    # - name: Install LaTeX (Windows)
+    #   if: startsWith(matrix.os, 'windows-')
+    #   uses: teatimeguest/setup-texlive-action@v3
+    #   with:
+    #     packages: >-
+    #       scheme-medium
+    #       collection-latexextra
+    #       babel-dutch
+    #       cjk
+    #       bibtex
+
+    # For Doxygen installation use action from https://github.com/marketplace/actions/doxygen-install.
+    - name: doxygen-install
+      uses: ssciwr/doxygen-install@v1.2.0
+
+    - name: Generate documentation
+      if: startsWith(matrix.os,'ubuntu-')
+      shell: sudo cmake -P {0}
+      run: |
+        execute_process(
+          COMMAND cmake --build build --target doc
+          RESULT_VARIABLE result
+        )
+        if (NOT result EQUAL 0)
+          message(FATAL_ERROR "Building documentation failed")
+        endif()
+
+    # See https://github.com/marketplace/actions/github-pages-action#%EF%B8%8F-deploy-to-external-repository-external_repository
+    # for more information on the parameters.
+    - name: Publish Documentation to Github Pages
+      uses: peaceiris/actions-gh-pages@v3
+      if: ${{ github.event_name == 'push' && startsWith(matrix.os,'ubuntu-') }}
+      with:
+         github_token: ${{ secrets.GITHUB_TOKEN }}
+         deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+         publish_dir: documentation/html
+         force_orphan: true
+         commit_message: ${{ github.event.head_commit.message }}
+         publish_branch: gh-pages
+         user_name: 'github-actions[bot]'
+         user_email: 'github-actions[bot]@users.noreply.github.com'


### PR DESCRIPTION
Why:
* Make workflow run less resource consuming by reusing results,
* The build fails not multiple times for different workflows, but once,
* Gives the workflow structure,
* Reduces the workflow size and simplifies adding new workflows easily.

On branch franziska-wegner/2024/january/CI/make-workflow-compact Changes to be committed:
	modified:   .github/workflows/cmake-multi-platform.yml
	new file:   .github/workflows/code-documentation.yml