### PR TITLE
Remove Test Raw String Warnings from C/C++ Linter

### DIFF
--- a/tests/Algorithms/PathFinding/TestDominatingThetaPath.cpp
+++ b/tests/Algorithms/PathFinding/TestDominatingThetaPath.cpp
@@ -47,7 +47,7 @@ TEST_F ( TestDTPEmptyGraph
         auto assertionString = buildAssertionString ( "DominatingThetaPath.hpp"
                                                     , "DominatingThetaPath"
                                                     , "Source"
-                                                    , "source < labelSets_.size\\(\\)");
+                                                    , R"(source < labelSets_.size\(\))");
 
         ASSERT_DEATH ( {dtp_.Source(0);}, assertionString );
     }
@@ -59,7 +59,7 @@ TEST_F ( TestDTPEmptyGraph
         auto assertionString = buildAssertionString ( "DominatingThetaPath.hpp"
                                                     , "DominatingThetaPath"
                                                     , "Source"
-                                                    , "source < labelSets_.size\\(\\)");
+                                                    , R"(source < labelSets_.size\(\))");
 
         try {
             dtp_.Source(0);

--- a/tests/DataStructures/Container/TestBinaryHeap.cpp
+++ b/tests/DataStructures/Container/TestBinaryHeap.cpp
@@ -60,7 +60,7 @@ TEST_F( TestBinaryHeap,
         auto assertionString = buildAssertionString ( "BinaryHeap.hpp"
                                                     , "BinaryHeap"
                                                     , "Top"
-                                                    , "!Empty\\(\\)");
+                                                    , R"(!Empty\(\))");
         ASSERT_DEATH( {heapConst_.Top();}, assertionString );
     }
 #else
@@ -71,7 +71,7 @@ TEST_F( TestBinaryHeap,
         auto assertionString = buildAssertionString ( "BinaryHeap.hpp"
                                                     , "BinaryHeap"
                                                     , "Top"
-                                                    , "!Empty\\(\\)");
+                                                    , R"(!Empty\(\))");
         try {
             heapConst_.Top();
         } catch ( std::runtime_error const & error ) {
@@ -221,7 +221,7 @@ TEST_F( TestBinaryHeap,
         auto assertionString = buildAssertionString ( "BinaryHeap.hpp"
                                                     , "BinaryHeap"
                                                     , "DecreaseKey"
-                                                    , "index < Size\\(\\)" );
+                                                    , R"(index < Size\(\))" );
 
         TElement p = -1;
 
@@ -235,7 +235,7 @@ TEST_F( TestBinaryHeap,
         auto assertionString = buildAssertionString ( "BinaryHeap.hpp"
                                                     , "BinaryHeap"
                                                     , "DecreaseKey"
-                                                    , "index < Size\\(\\)" );
+                                                    , R"(index < Size\(\))" );
         TElement p = -1;
 
         try {
@@ -257,7 +257,7 @@ TEST_F( TestBinaryHeap,
         auto assertionString = buildAssertionString ( "BinaryHeap.hpp"
                                                     , "BinaryHeap"
                                                     , "ChangeKey"
-                                                    , "index < Size\\(\\)");
+                                                    , R"(index < Size\(\))");
 
         TElement p = -1;
 
@@ -271,7 +271,7 @@ TEST_F( TestBinaryHeap,
         auto assertionString = buildAssertionString ( "BinaryHeap.hpp"
                                                     , "BinaryHeap"
                                                     , "ChangeKey"
-                                                    , "index < Size\\(\\)");
+                                                    , R"(index < Size\(\))");
         TElement p = -1;
 
         try {
@@ -339,7 +339,7 @@ TEST_F( TestBinaryHeap,
         auto assertionString = buildAssertionString ( "BinaryHeap.hpp"
                                                     , "BinaryHeap"
                                                     , "Pop"
-                                                    , "Size\\(\\) > 0");
+                                                    , R"(Size\(\) > 0)");
         ASSERT_DEATH( {heap_.Pop();}, assertionString );
     }
 #else
@@ -350,7 +350,7 @@ TEST_F( TestBinaryHeap,
         auto assertionString = buildAssertionString ( "BinaryHeap.hpp"
                                                     , "BinaryHeap"
                                                     , "Pop"
-                                                    , "Size\\(\\) > 0");
+                                                    , R"(Size\(\) > 0)");
         try {
             heap_.Pop();
         } catch ( std::runtime_error const & error ) {
@@ -370,7 +370,7 @@ TEST_F( TestBinaryHeap,
         auto assertionString = buildAssertionString ( "BinaryHeap.hpp"
                                                     , "BinaryHeap"
                                                     , "DeleteTop"
-                                                    , "Size\\(\\) > 0");
+                                                    , R"(Size\(\) > 0)");
 
         ASSERT_DEATH( {heap_.DeleteTop();}, assertionString );
     }
@@ -382,7 +382,7 @@ TEST_F( TestBinaryHeap,
         auto assertionString = buildAssertionString ( "BinaryHeap.hpp"
                                                     , "BinaryHeap"
                                                     , "DeleteTop"
-                                                    , "Size\\(\\) > 0");
+                                                    , R"(Size\(\) > 0)");
         try {
             heap_.DeleteTop();
         } catch ( std::runtime_error const & error ) {
@@ -718,7 +718,7 @@ TEST_F (TestBinaryHeapWithOneIntegerElement,
         auto assertionString = buildAssertionString ( "BinaryHeap.hpp"
                                                     , "BinaryHeap"
                                                     , "DecreaseKey"
-                                                    , "index < Size\\(\\)" );
+                                                    , R"(index < Size\(\))" );
 
         ASSERT_DEATH( {heap_.DecreaseKey(7, 123);}, assertionString );
     }
@@ -730,7 +730,7 @@ TEST_F (TestBinaryHeapWithOneIntegerElement,
         auto assertionString = buildAssertionString ( "BinaryHeap.hpp"
                                                     , "BinaryHeap"
                                                     , "DecreaseKey"
-                                                    , "index < Size\\(\\)" );
+                                                    , R"(index < Size\(\))" );
         try {
             heap_.DecreaseKey(7, 123);
         } catch ( std::runtime_error const & error ) {
@@ -785,7 +785,7 @@ TEST_F (TestBinaryHeapWithOneIntegerElement,
         auto assertionString = buildAssertionString ( "BinaryHeap.hpp"
                                                     , "BinaryHeap"
                                                     , "ChangeKey"
-                                                    , "index < Size\\(\\)");
+                                                    , R"(index < Size\(\))");
 
         ASSERT_DEATH( {heap_.ChangeKey(7, 123);}, assertionString );
     }
@@ -797,7 +797,7 @@ TEST_F (TestBinaryHeapWithOneIntegerElement,
         auto assertionString = buildAssertionString ( "BinaryHeap.hpp"
                                                     , "BinaryHeap"
                                                     , "ChangeKey"
-                                                    , "index < Size\\(\\)");
+                                                    , R"(index < Size\(\))");
         try {
             heap_.ChangeKey(7, 123);
         } catch ( std::runtime_error const & error ) {

--- a/tests/DataStructures/Container/TestBucket.cpp
+++ b/tests/DataStructures/Container/TestBucket.cpp
@@ -38,7 +38,7 @@ namespace egoa::test {
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "Top"
-                                                    , "!EmptyQueue\\(\\)");
+                                                    , R"(!EmptyQueue\(\))");
         ASSERT_DEATH ( {bucket_.Top();}, ".*" );
     }
 #else
@@ -49,7 +49,7 @@ namespace egoa::test {
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "Top"
-                                                    , "!EmptyQueue\\(\\)");
+                                                    , R"(!EmptyQueue\(\))");
         try {
             bucket_.Top();
         } catch ( std::runtime_error const & error )
@@ -75,7 +75,7 @@ namespace egoa::test {
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "operator.*<"
-                                                    , "!EmptyQueue\\(\\)");
+                                                    , R"(!EmptyQueue\(\))");
         ASSERT_DEATH ( { auto test = bucket_ < bucketToCompare_;}, assertionString );
     }
 #else
@@ -87,7 +87,7 @@ namespace egoa::test {
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "operator.*<"
-                                                    , "!EmptyQueue\\(\\)");
+                                                    , R"(!EmptyQueue\(\))");
         try {
             auto test = bucket_ < bucketToCompare_;
         } catch ( std::runtime_error const & error )
@@ -110,7 +110,7 @@ namespace egoa::test {
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "operator.*<="
-                                                    , "!EmptyQueue\\(\\)");
+                                                    , R"(!EmptyQueue\(\))");
         ASSERT_DEATH ( { auto test = bucket_ <= bucketToCompare_;}, assertionString );
     }
 #else
@@ -122,7 +122,7 @@ namespace egoa::test {
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "operator.*<="
-                                                    , "!EmptyQueue\\(\\)");
+                                                    , R"(!EmptyQueue\(\))");
         try {
             auto test = bucket_ <= bucketToCompare_;
         } catch ( std::runtime_error const & error )
@@ -145,7 +145,7 @@ namespace egoa::test {
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "operator.*>"
-                                                    , "!EmptyQueue\\(\\)");
+                                                    , R"(!EmptyQueue\(\))");
         ASSERT_DEATH ( { auto test = bucket_ > bucketToCompare_;}, assertionString );
     }
 #else
@@ -157,7 +157,7 @@ namespace egoa::test {
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "operator.*>"
-                                                    , "!EmptyQueue\\(\\)");
+                                                    , R"(!EmptyQueue\(\))");
         try {
             auto test = bucket_ > bucketToCompare_;
         } catch ( std::runtime_error const & error )
@@ -180,7 +180,7 @@ namespace egoa::test {
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "operator.*>="
-                                                    , "!EmptyQueue\\(\\)");
+                                                    , R"(!EmptyQueue\(\))");
         ASSERT_DEATH ( { auto test = bucket_ >= bucketToCompare_;}, assertionString );
     }
 #else
@@ -192,7 +192,7 @@ namespace egoa::test {
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "operator.*>="
-                                                    , "!EmptyQueue\\(\\)");
+                                                    , R"(!EmptyQueue\(\))");
         try {
             auto test = bucket_ >= bucketToCompare_;
         } catch ( std::runtime_error const & error )
@@ -294,7 +294,7 @@ TEST_F  ( TestBucketWithZeroElements
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "ElementAt"
-                                                    , "HasElementAt\\(index\\)");
+                                                    , R"(HasElementAt\(index\))");
         ASSERT_DEATH ( {bucket_.ElementAt(0);},  assertionString );
         ASSERT_DEATH ( {bucket_.ElementAt(1);},  assertionString );
         ASSERT_DEATH ( {bucket_.ElementAt(-1);}, assertionString );
@@ -307,7 +307,7 @@ TEST_F  ( TestBucketWithZeroElements
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "ElementAt"
-                                                    , "HasElementAt\\(index\\)");
+                                                    , R"(HasElementAt\(index\))");
         try {
             try {
                 bucket_.ElementAt(0);
@@ -342,8 +342,8 @@ TEST_F  ( TestBucketWithZeroElements
     {
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
-                                                    , "operator.*\\[\\]"
-                                                    , "HasElementAt\\(index\\)");
+                                                    , R"(operator.*\[\])"
+                                                    , R"(HasElementAt\(index\))");
         ASSERT_DEATH ( {bucket_[0];},  assertionString );
         ASSERT_DEATH ( {bucket_[1];},  assertionString );
         ASSERT_DEATH ( {bucket_[-1];}, assertionString );
@@ -355,8 +355,8 @@ TEST_F  ( TestBucketWithZeroElements
     {
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
-                                                    , "operator.*\\[\\]"
-                                                    , "HasElementAt\\(index\\)");
+                                                    , R"(operator.*\[\])"
+                                                    , R"(HasElementAt\(index\))");
         try {
             try {
                 bucket_[0];
@@ -395,7 +395,7 @@ TEST_F  ( TestBucketWithZeroElements
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "Top"
-                                                    , "!EmptyQueue\\(\\)");
+                                                    , R"(!EmptyQueue\(\))");
         EXPECT_TRUE  ( bucket_.EmptyQueue() );
         ASSERT_DEATH ( {bucket_.Top();}, assertionString );
     }
@@ -407,7 +407,7 @@ TEST_F  ( TestBucketWithZeroElements
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "Top"
-                                                    , "!EmptyQueue\\(\\)");
+                                                    , R"(!EmptyQueue\(\))");
         EXPECT_TRUE  ( bucket_.EmptyQueue() );
         try {
             bucket_.Top();
@@ -439,7 +439,7 @@ TEST_F  ( TestBucketWithZeroElements
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "Pop"
-                                                    , "!EmptyQueue\\(\\)" );
+                                                    , R"(!EmptyQueue\(\))" );
         ASSERT_DEATH ( {bucket_.Pop();}, assertionString );
     }
 #else
@@ -450,7 +450,7 @@ TEST_F  ( TestBucketWithZeroElements
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "Pop"
-                                                    , "!EmptyQueue\\(\\)" );
+                                                    , R"(!EmptyQueue\(\))" );
         try {
             bucket_.Pop();
         } catch ( std::runtime_error const & error )
@@ -472,7 +472,7 @@ TEST_F  ( TestBucketWithZeroElements
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "DeleteTop"
-                                                    , "!EmptyQueue\\(\\)" );
+                                                    , R"(!EmptyQueue\(\))" );
         ASSERT_DEATH ( {bucket_.DeleteTop();}, assertionString );
     }
 #else
@@ -483,7 +483,7 @@ TEST_F  ( TestBucketWithZeroElements
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "DeleteTop"
-                                                    , "!EmptyQueue\\(\\)" );
+                                                    , R"(!EmptyQueue\(\))" );
         try {
             bucket_.DeleteTop();
         } catch ( std::runtime_error const & error )
@@ -687,7 +687,7 @@ TEST_F  ( TestBucketWithZeroElements
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "operator.*<"
-                                                    , "!rhs.EmptyQueue\\(\\)" );
+                                                    , R"(!rhs.EmptyQueue\(\))" );
         ASSERT_DEATH ( { auto test = bucket_ < bucketToCompare_;}, assertionString );
     }
 #else
@@ -699,7 +699,7 @@ TEST_F  ( TestBucketWithZeroElements
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "operator.*<"
-                                                    , "!rhs.EmptyQueue\\(\\)" );
+                                                    , R"(!rhs.EmptyQueue\(\))" );
         try {
             auto test = bucket_ < bucketToCompare_;
         } catch ( std::runtime_error const & error )
@@ -726,7 +726,7 @@ TEST_F  ( TestBucketWithZeroElements
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "operator.*<="
-                                                    , "!rhs.EmptyQueue\\(\\)" );
+                                                    , R"(!rhs.EmptyQueue\(\))" );
         ASSERT_DEATH ( { auto test = bucket_ <= bucketToCompare_;}, assertionString );
     }
 #else
@@ -738,7 +738,7 @@ TEST_F  ( TestBucketWithZeroElements
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "operator.*<="
-                                                    , "!rhs.EmptyQueue\\(\\)" );
+                                                    , R"(!rhs.EmptyQueue\(\))" );
         try {
             auto test = bucket_ <= bucketToCompare_;
         } catch ( std::runtime_error const & error ) {
@@ -763,7 +763,7 @@ TEST_F  ( TestBucketWithZeroElements
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "operator.*>"
-                                                    , "!rhs.EmptyQueue\\(\\)" );
+                                                    , R"(!rhs.EmptyQueue\(\))" );
         ASSERT_DEATH ( { auto test = bucket_ > bucketToCompare_;}
                      , assertionString );
     }
@@ -776,7 +776,7 @@ TEST_F  ( TestBucketWithZeroElements
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "operator.*>"
-                                                    , "!rhs.EmptyQueue\\(\\)" );
+                                                    , R"(!rhs.EmptyQueue\(\))" );
         try {
             auto test = bucket_ > bucketToCompare_;
         } catch ( std::runtime_error const & error )
@@ -804,7 +804,7 @@ TEST_F  ( TestBucketWithZeroElements
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "operator.*>="
-                                                    , "!rhs.EmptyQueue\\(\\)");
+                                                    , R"(!rhs.EmptyQueue\(\))");
         ASSERT_DEATH ( { auto test = bucket_ >= bucketToCompare_;}
                      , assertionString );
     }
@@ -817,7 +817,7 @@ TEST_F  ( TestBucketWithZeroElements
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "operator.*>="
-                                                    , "!rhs.EmptyQueue\\(\\)");
+                                                    , R"(!rhs.EmptyQueue\(\))");
         try {
             auto test = bucket_ >= bucketToCompare_;
         } catch ( std::runtime_error const & error )
@@ -918,7 +918,7 @@ TEST_F  ( TestBucketWithMultipleInteger
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "ElementAt"
-                                                    , "HasElementAt\\(index\\)" );
+                                                    , R"(HasElementAt\(index\))" );
 
         ASSERT_DEATH ( {bucket_.ElementAt(0);},  assertionString );
         ASSERT_DEATH ( {bucket_.ElementAt(1);},  assertionString );
@@ -934,7 +934,7 @@ TEST_F  ( TestBucketWithMultipleInteger
         auto assertionString2 = buildAssertionString ( "Bucket.hpp"
                                                      , "Bucket"
                                                      , "Pop"
-                                                     , "!EmptyQueue\\(\\)" );
+                                                     , R"(!EmptyQueue\(\))" );
         ASSERT_DEATH ( {bucket_.Pop();}, assertionString2 );
     }
 #else
@@ -945,7 +945,7 @@ TEST_F  ( TestBucketWithMultipleInteger
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "ElementAt"
-                                                    , "HasElementAt\\(index\\)" );
+                                                    , R"(HasElementAt\(index\))" );
         try {
             try {
                 bucket_.ElementAt(0);
@@ -976,7 +976,7 @@ TEST_F  ( TestBucketWithMultipleInteger
             auto assertionString2 = buildAssertionString ( "Bucket.hpp"
                                                          , "Bucket"
                                                          , "Pop"
-                                                         , "!EmptyQueue\\(\\)" );
+                                                         , R"(!EmptyQueue\(\))" );
             try {
                 bucket_.Pop();
             } catch ( std::runtime_error const & error )
@@ -1002,8 +1002,8 @@ TEST_F  ( TestBucketWithMultipleInteger
 
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
-                                                    , "operator.*\\[\\]"
-                                                    , "HasElementAt\\(index\\)" );
+                                                    , R"(operator.*\[\])"
+                                                    , R"(HasElementAt\(index\))" );
 
         ASSERT_DEATH ( { bucket_[0];  }, assertionString );
         ASSERT_DEATH ( { bucket_[1];  }, assertionString );
@@ -1016,8 +1016,8 @@ TEST_F  ( TestBucketWithMultipleInteger
     {
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
-                                                    , "operator.*\\[\\]"
-                                                    , "HasElementAt\\(index\\)" );
+                                                    , R"(operator.*\[\])"
+                                                    , R"(HasElementAt\(index\))" );
         try {
             try {
                 bucket_[0];
@@ -1092,7 +1092,7 @@ TEST_F  ( TestBucketWithMultipleInteger
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "Pop"
-                                                    , "!EmptyQueue\\(\\)" );
+                                                    , R"(!EmptyQueue\(\))" );
         ASSERT_DEATH ( {bucket_.Pop();}, assertionString );
 
         bucket_.template for_all_processed_elements<egoa::ExecutionPolicy::sequential>(
@@ -1116,7 +1116,7 @@ TEST_F  ( TestBucketWithMultipleInteger
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "Pop"
-                                                    , "!EmptyQueue\\(\\)" );
+                                                    , R"(!EmptyQueue\(\))" );
         try {
             bucket_.Pop();
         } catch ( std::runtime_error const & error )
@@ -1157,7 +1157,7 @@ TEST_F  ( TestBucketWithMultipleInteger
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "DeleteTop"
-                                                    , "!EmptyQueue\\(\\)" );
+                                                    , R"(!EmptyQueue\(\))" );
         ASSERT_DEATH ( {bucket_.DeleteTop();}, assertionString );
 
         bucket_.template for_all_processed_elements<egoa::ExecutionPolicy::sequential>(
@@ -1183,7 +1183,7 @@ TEST_F  ( TestBucketWithMultipleInteger
         auto assertionString = buildAssertionString ( "Bucket.hpp"
                                                     , "Bucket"
                                                     , "DeleteTop"
-                                                    , "!EmptyQueue\\(\\)" );
+                                                    , R"(!EmptyQueue\(\))" );
         try {
             bucket_.DeleteTop();
         } catch ( std::runtime_error const & error )

--- a/tests/DataStructures/Container/TestMappingBinaryHeap.cpp
+++ b/tests/DataStructures/Container/TestMappingBinaryHeap.cpp
@@ -71,7 +71,7 @@ TEST_F(TestMappingBinaryHeapWithMultipleElements, Content) {
         auto assertionString = buildAssertionString ( "MappingBinaryHeap.hpp"
                                                     , "MappingBinaryHeap"
                                                     , "Top"
-                                                    , "!Empty\\(\\)");
+                                                    , R"(!Empty\(\))");
         ASSERT_DEATH({heapConst_.Top();}, assertionString);
     }
 #else
@@ -82,7 +82,7 @@ TEST_F(TestMappingBinaryHeapWithMultipleElements, Content) {
         auto assertionString = buildAssertionString ( "BinaryHeap.hpp"
                                                     , "BinaryHeap"
                                                     , "Top"
-                                                    , "!Empty\\(\\)");
+                                                    , R"(!Empty\(\))");
         try {
             heapConst_.Top();
         } catch ( std::runtime_error const & error ) {
@@ -115,7 +115,7 @@ TEST_F(TestMappingBinaryHeapWithMultipleElements, Top) {
         auto assertionString = buildAssertionString ( "MappingBinaryHeap.hpp"
                                                     , "MappingBinaryHeap"
                                                     , "TopElement"
-                                                    , "!Empty\\(\\)");
+                                                    , R"(!Empty\(\))");
         ASSERT_DEATH( {heapConst_.TopElement();}, assertionString );
     }
 #else
@@ -126,7 +126,7 @@ TEST_F(TestMappingBinaryHeapWithMultipleElements, Top) {
         auto assertionString = buildAssertionString ( "BinaryHeap.hpp"
                                                     , "BinaryHeap"
                                                     , "TopElement"
-                                                    , "!Empty\\(\\)");
+                                                    , R"(!Empty\(\))");
         try {
             heapConst_.TopElement();
         } catch ( std::runtime_error const & error ) {
@@ -155,7 +155,7 @@ TEST_F(TestMappingBinaryHeapWithMultipleElements, TopElement) {
         auto assertionString = buildAssertionString ( "MappingBinaryHeap.hpp"
                                                     , "MappingBinaryHeap"
                                                     , "TopKey"
-                                                    , "!Empty\\(\\)");
+                                                    , R"(!Empty\(\))");
         ASSERT_DEATH( {heapConst_.TopKey();}, assertionString );
     }
 #else
@@ -166,7 +166,7 @@ TEST_F(TestMappingBinaryHeapWithMultipleElements, TopElement) {
         auto assertionString = buildAssertionString ( "MappingBinaryHeap.hpp"
                                                     , "MappingBinaryHeap"
                                                     , "TopKey"
-                                                    , "!Empty\\(\\)");
+                                                    , R"(!Empty\(\))");
         try {
             heapConst_.TopKey();
         } catch ( std::runtime_error const & error ) {
@@ -815,7 +815,7 @@ TEST_F(TestMappingBinaryHeapWithMultipleElements, EmplaceEqual) {
         auto assertionString = buildAssertionString ( "BinaryHeap.hpp"
                                                     , "BinaryHeap"
                                                     , "DeleteTop"
-                                                    , "!Empty\\(\\)");
+                                                    , R"(!Empty\(\))");
         ASSERT_DEATH( {heap_.DeleteTop();}, assertionString );
     }
 #else
@@ -826,7 +826,7 @@ TEST_F(TestMappingBinaryHeapWithMultipleElements, EmplaceEqual) {
         auto assertionString = buildAssertionString ( "BinaryHeap.hpp"
                                                     , "BinaryHeap"
                                                     , "DeleteTop"
-                                                    , "!Empty\\(\\)");
+                                                    , R"(!Empty\(\))");
         try {
             heap_.DeleteTop();
         } catch ( std::runtime_error const & error ) {
@@ -867,7 +867,7 @@ TEST_F(TestMappingBinaryHeapWithMultipleElements, DeleteTop) {
         auto assertionString = buildAssertionString ( "MappingBinaryHeap.hpp"
                                                     , "MappingBinaryHeap"
                                                     , "Pop"
-                                                    , "!Empty\\(\\)");
+                                                    , R"(!Empty\(\))");
         ASSERT_DEATH( {heap_.Pop();}, assertionString );
     }
 #else
@@ -878,7 +878,7 @@ TEST_F(TestMappingBinaryHeapWithMultipleElements, DeleteTop) {
         auto assertionString = buildAssertionString ( "MappingBinaryHeap.hpp"
                                                     , "MappingBinaryHeap"
                                                     , "Pop"
-                                                    , "!Empty\\(\\)");
+                                                    , R"(!Empty\(\))");
         try {
             heap_.Pop();
         } catch ( std::runtime_error const & error ) {

--- a/tests/DataStructures/Graphs/TestDynamicGraph.cpp
+++ b/tests/DataStructures/Graphs/TestDynamicGraph.cpp
@@ -16,7 +16,7 @@ namespace egoa::test {
 #ifdef EGOA_ENABLE_ASSERTION
     TEST_F(TestDynamicGraphEmptyDeathTest, DeleteVertex) {
         auto assertionMessage =
-            this->assertionString("RemoveVertexAt", "VertexExists\\(id\\)");
+            this->assertionString("RemoveVertexAt", R"(VertexExists\(id\))");
         Types::vertexId id = 0;
         EXPECT_DEATH( { this->graph_.RemoveVertexAt(id); }, assertionMessage);
     }
@@ -25,7 +25,7 @@ namespace egoa::test {
     TEST_F  ( TestDynamicGraphEmpty
             , DeleteVertexExceptionHandling )
     {
-        auto assertionString = this->assertionString("RemoveVertexAt", "VertexExists\\(id\\)");
+        auto assertionString = this->assertionString("RemoveVertexAt", R"(VertexExists\(id\))");
         Types::vertexId id = 0;
         try {
             this->graph_.RemoveVertexAt(id);

--- a/tests/DataStructures/Graphs/TestGraph.cpp
+++ b/tests/DataStructures/Graphs/TestGraph.cpp
@@ -944,7 +944,7 @@ TYPED_TEST( TestGraphStar, EdgesIterateBackwardsConst) {
 #pragma mark VertexAt
 #ifdef EGOA_ENABLE_ASSERTION
     TYPED_TEST(TestGraphEmptyDeathTest, VertexAt) {
-        auto assertionString = this->assertionString("VertexAt", "VertexExists\\(id\\)");
+        auto assertionString = this->assertionString("VertexAt", R"(VertexExists\(id\))");
         Types::vertexId id = 0;
         EXPECT_DEATH( {this->graph_.VertexAt(id);}, assertionString);
         EXPECT_DEATH( {this->graphConst_.VertexAt(id);}, assertionString);
@@ -956,7 +956,7 @@ TYPED_TEST( TestGraphStar, EdgesIterateBackwardsConst) {
                 , VertexAtExceptionHandling )
     {
         auto assertionString = this->assertionString( "VertexAt"
-                                                    , "VertexExists\\(id\\)");
+                                                    , R"(VertexExists\(id\))");
         Types::vertexId id = 0;
         try {
             this->graph_.VertexAt(id);
@@ -981,7 +981,7 @@ TYPED_TEST( TestGraphStar, EdgesIterateBackwardsConst) {
 
 #ifdef EGOA_ENABLE_ASSERTION
 TYPED_TEST(TestGraphSingleVertexDeathTest, VertexAt) {
-    auto assertionString = this->assertionString("VertexAt", "VertexExists\\(id\\)");
+    auto assertionString = this->assertionString("VertexAt", R"(VertexExists\(id\))");
     Types::vertexId id = this->id_ + 1;
     EXPECT_DEATH( {this->graph_.VertexAt(id);}, assertionString);
     EXPECT_DEATH( {this->graphConst_.VertexAt(id);}, assertionString);
@@ -992,7 +992,7 @@ TYPED_TEST(TestGraphSingleVertexDeathTest, VertexAt) {
                 , VertexAtExceptionHandling )
     {
         auto assertionString = this->assertionString( "VertexAt"
-                                                    , "VertexExists\\(id\\)");
+                                                    , R"(VertexExists\(id\))");
         Types::vertexId id = this->id_ + 1;
         try {
             this->graph_.VertexAt(id);
@@ -1016,7 +1016,7 @@ TYPED_TEST(TestGraphSingleVertexDeathTest, VertexAt) {
 
 #ifdef EGOA_ENABLE_ASSERTION
     TYPED_TEST(TestGraphFourVerticesDeathTest, VertexAt) {
-        auto assertionString = this->assertionString("VertexAt", "VertexExists\\(id\\)");
+        auto assertionString = this->assertionString("VertexAt", R"(VertexExists\(id\))");
         Types::vertexId id = Const::NONE;
         EXPECT_DEATH( {this->graph_.VertexAt(id);}, assertionString);
         EXPECT_DEATH( {this->graphConst_.VertexAt(id);}, assertionString);
@@ -1027,7 +1027,7 @@ TYPED_TEST(TestGraphSingleVertexDeathTest, VertexAt) {
                 , VertexAtExceptionHandling )
     {
         auto assertionString = this->assertionString( "VertexAt"
-                                                    , "VertexExists\\(id\\)");
+                                                    , R"(VertexExists\(id\))");
         Types::vertexId id = Const::NONE;
         try {
             this->graph_.VertexAt(id);
@@ -1068,7 +1068,7 @@ TYPED_TEST(TestGraphStar, VertexAt) {
 /// @todo death tests for neighbors of non-existent vertices
 #ifdef EGOA_ENABLE_ASSERTION
     TYPED_TEST(TestGraphEmptyDeathTest, NeighborsOf) {
-        auto assertionString = this->assertionString("NeighborsOf", "VertexExists\\(id\\)");
+        auto assertionString = this->assertionString("NeighborsOf", R"(VertexExists\(id\))");
         Types::vertexId id = 0;
         EXPECT_DEATH( {this->graph_.NeighborsOf(id);}, assertionString);
         EXPECT_DEATH( {this->graphConst_.NeighborsOf(id);}, assertionString);
@@ -1079,7 +1079,7 @@ TYPED_TEST(TestGraphStar, VertexAt) {
                 , NeighborsOfExceptionHandling )
     {
         auto assertionString = this->assertionString( "NeighborsOf"
-                                                    , "VertexExists\\(id\\)");
+                                                    , R"(VertexExists\(id\))");
         Types::vertexId id = 0;
         try {
             this->graph_.NeighborsOf(id);
@@ -1103,7 +1103,7 @@ TYPED_TEST(TestGraphStar, VertexAt) {
 
 #ifdef EGOA_ENABLE_ASSERTION
     TYPED_TEST(TestGraphSingleVertexDeathTest, NeighborsOf) {
-        auto assertionString = this->assertionString("NeighborsOf", "VertexExists\\(id\\)");
+        auto assertionString = this->assertionString("NeighborsOf", R"(VertexExists\(id\))");
         Types::vertexId id = this->id_ + 1;
         EXPECT_DEATH( {this->graph_.NeighborsOf(id);}, assertionString);
         EXPECT_DEATH( {this->graphConst_.NeighborsOf(id);}, assertionString);
@@ -1114,7 +1114,7 @@ TYPED_TEST(TestGraphStar, VertexAt) {
                 , NeighborsOfExceptionHandling )
     {
         auto assertionString = this->assertionString( "NeighborsOf"
-                                                    , "VertexExists\\(id\\)");
+                                                    , R"(VertexExists\(id\))");
         Types::vertexId id = this->id_ + 1;
         try {
             this->graph_.NeighborsOf(id);
@@ -1138,7 +1138,7 @@ TYPED_TEST(TestGraphStar, VertexAt) {
 
 #ifdef EGOA_ENABLE_ASSERTION
     TYPED_TEST(TestGraphFourVerticesDeathTest, NeighborsOf) {
-        auto assertionString = this->assertionString("NeighborsOf", "VertexExists\\(id\\)");
+        auto assertionString = this->assertionString("NeighborsOf", R"(VertexExists\(id\))");
         Types::vertexId id = Const::NONE;
         EXPECT_DEATH( {this->graph_.NeighborsOf(id);}, assertionString);
         EXPECT_DEATH( {this->graphConst_.NeighborsOf(id);}, assertionString);
@@ -1149,7 +1149,7 @@ TYPED_TEST(TestGraphStar, VertexAt) {
                 , NeighborsOfExceptionHandling )
     {
         auto assertionString = this->assertionString( "NeighborsOf"
-                                                    , "VertexExists\\(id\\)");
+                                                    , R"(VertexExists\(id\))");
         Types::vertexId id = Const::NONE;
         try {
             this->graph_.NeighborsOf(id);
@@ -2149,7 +2149,7 @@ TYPED_TEST(TestGraphStar, ForAllEdgeTuplesConst) {
 #pragma mark ForAllEdgesAt
 #ifdef EGOA_ENABLE_ASSERTION
 TYPED_TEST(TestGraphEmptyDeathTest, ForAllEdgesAt) {
-    auto assertionString = this->assertionString("for_all_edges_at", "VertexExists\\(vertexId\\)");
+    auto assertionString = this->assertionString("for_all_edges_at", R"(VertexExists\(vertexId\))");
     Types::vertexId nonexistentId = 3;
     EXPECT_DEATH(
         { this->graph_.template for_all_edges_at<egoa::ExecutionPolicy::sequential>(
@@ -2166,7 +2166,7 @@ TYPED_TEST(TestGraphEmptyDeathTest, ForAllEdgesAt) {
                 , ForAllEdgesAtExceptionHandling )
     {
         auto assertionString = this->assertionString( "for_all_edges_at"
-                                                    , "VertexExists\\(vertexId\\)");
+                                                    , R"(VertexExists\(vertexId\))");
         Types::vertexId nonexistentId = 3;
         try {
             this->graph_.template for_all_edges_at<egoa::ExecutionPolicy::sequential>(
@@ -2188,7 +2188,7 @@ TYPED_TEST(TestGraphEmptyDeathTest, ForAllEdgesAt) {
 
 #ifdef EGOA_ENABLE_ASSERTION
 TYPED_TEST(TestGraphEmptyDeathTest, ForAllEdgesAtConst) {
-    auto assertionString = this->assertionString("for_all_edges_at", "VertexExists\\(vertexId\\)");
+    auto assertionString = this->assertionString("for_all_edges_at", R"(VertexExists\(vertexId\))");
     Types::vertexId nonexistentId = 3;
     EXPECT_DEATH(
         { this->graphConst_.template for_all_edges_at<egoa::ExecutionPolicy::sequential>(
@@ -2205,7 +2205,7 @@ TYPED_TEST(TestGraphEmptyDeathTest, ForAllEdgesAtConst) {
                 , ForAllEdgesAtConstExceptionHandling )
     {
         auto assertionString = this->assertionString( "for_all_edges_at"
-                                                    , "VertexExists\\(vertexId\\)");
+                                                    , R"(VertexExists\(vertexId\))");
         Types::vertexId nonexistentId = 3;
         try {
             this->graphConst_.template for_all_edges_at<egoa::ExecutionPolicy::sequential>(

--- a/tests/IO/TestPyPsaParser.cpp
+++ b/tests/IO/TestPyPsaParser.cpp
@@ -292,7 +292,7 @@ TEST_F ( PyPSAExampleInconsistencyGeneratorsDeathTest
     auto assertionString = buildAssertionString ( "PyPsaParser.hpp"
                                                 , "PyPsaParser"
                                                 , "ExtractGeneratorMaximumRealPowerPuHeader"
-                                                , "false && \"Generator name does not exist\"");
+                                                , R"(false && "Generator name does not exist")");
     EXPECT_DEATH({egoa::PowerGridIO<TGraph>::read( network_
                                                  , graph_
                                                  , TestCaseSmallExample_
@@ -318,7 +318,7 @@ TEST_F ( PyPSAExampleDuplicatedGeneratorsDeathTest
     auto assertionString = buildAssertionString ( "PyPsaParser.hpp"
                                                 , "PyPsaParser"
                                                 , "AddNameToGenerator"
-                                                , "false && \"Generator duplicates\"");
+                                                , R"(false && "Generator duplicates")");
     EXPECT_DEATH({egoa::PowerGridIO<TGraph>::read( network_
                                                  , graph_
                                                  , TestCaseSmallExample_


### PR DESCRIPTION
This PR removes some warnings by using raw strings that avoids escaping sequences.