### PR TITLE
Replace Deprecated  `assert.h` Header with `cassert`

### DIFF
--- a/src/Runnables/main.cpp
+++ b/src/Runnables/main.cpp
@@ -32,10 +32,10 @@
 #include <QApplication>
 #include <QCommandLineParser>
 
-#include <memory>
+#include <cassert>
 #include <cmath>
 #include <ctime>
-#include <assert.h>
+#include <memory>
 #include <type_traits>
 
 #include "DataStructures/Networks/PowerGrid.hpp"


### PR DESCRIPTION
This PR removes the following C/C++ linter warning, which highlights a deprecated include header `assert.h` and asks to replace it with `cassert`.

<img width="546" alt="Screenshot 2024-01-02 at 6 24 10 AM" src="https://github.com/franziska-wegner/egoa/assets/57569315/378140a6-a7f3-4042-96ed-5798b29b8d2c">
