### PR TITLE
Add DTP Runtime Row and Collection for Statistics

### DIFF
--- a/include/IO/Statistics/DtpRuntimeCollection.hpp
+++ b/include/IO/Statistics/DtpRuntimeCollection.hpp
@@ -1,0 +1,113 @@
+/*
+ * DtpRuntimeCollection.hpp
+ *
+ *  Created on: Feb 26, 2019
+ *      Author: Franziska Wegner, Matthias Wolf
+ */
+
+#ifndef EGOA__IO__STATISTICS__DTP_RUNTIME_COLLECTION_HPP
+#define EGOA__IO__STATISTICS__DTP_RUNTIME_COLLECTION_HPP
+
+#include <fstream>
+#include <iostream>
+#include <vector>
+
+#include "IO/Statistics/DtpRuntimeRow.hpp"
+
+namespace egoa::IO {
+
+/**
+ * @brief      A collections of DtpRuntimeRow objects for multiple runs
+ *             of the DTP-algorithm.
+ */
+class DtpRuntimeCollection {
+    public:
+        using TRow = DtpRuntimeRow;
+    public:
+        /// @name Modifying content
+        /// @{
+        /**
+         * @brief      Adds a DtpRuntimeRow to the collection.
+         *
+         * @param      rhs   The row to add.
+         *
+         * @return     @c *this.
+         */
+        inline DtpRuntimeCollection & operator+=( TRow const & rhs )
+        {
+            collection_.emplace_back ( rhs );
+            return *this;
+        }
+
+        /**
+         * @brief      Clears the content of the collection.
+         */
+        inline void Clear ()
+        {
+            collection_.clear();
+        }
+        /// @}
+
+        /// @name Accessors
+        /// @{
+        inline std::vector<TRow> const & Collection () const
+        {
+            return collection_;
+        }
+        /// @}
+
+        /// @name Output
+        /// @{
+            friend std::ostream & operator<<( std::ostream & os, DtpRuntimeCollection const & collection )
+            {
+                for ( const auto & row : collection.collection_ )
+                {
+                    row.Content(os);
+                }
+                return os;
+            }
+
+            /**
+             * @brief      Writes the data in the collection to a file.
+             *
+             * @details    If <tt>overwrite == true</tt> or the file is empty,
+             *             a header is written before the content.
+             *             Otherwise, onlye the content is written.
+             *
+             * @param[in]  filename   The filename
+             * @param[in]  overwrite  @c true if the content of the file shall be
+             *                        overwritten, @p false if the content shall be
+             *                        appended to the file.
+             */
+            inline void WriteCollectionToFileWith ( Types::string const filename
+                                                  , bool                overwrite = true )
+            {
+#ifndef NDEBUG
+                std::cout << "Write DTP runtime information row to: " << filename << std::endl;
+#endif
+                // Open output stream.
+                std::ofstream fileStream;
+                fileStream.open( filename, overwrite ? std::ofstream::trunc : std::ofstream::app );
+                if ( !fileStream.is_open() ) return;
+
+                // Check if the file is empty
+                fileStream.seekp(0, std::ios::end);
+                if ( fileStream.tellp() == 0 )
+                {
+                    TRow::Header ( fileStream );
+                }
+
+                for ( const auto & row : collection_ )
+                { 
+                    row.Content(fileStream);
+                }
+            }
+        /// @}
+
+    private:
+        std::vector<TRow> collection_;
+};
+
+} // namespace egoa::IO
+
+#endif // EGOA__IO__STATISTICS__DTP_RUNTIME_COLLECTION_HPP

--- a/include/IO/Statistics/DtpRuntimeCollection.hpp
+++ b/include/IO/Statistics/DtpRuntimeCollection.hpp
@@ -98,7 +98,7 @@ class DtpRuntimeCollection {
                 }
 
                 for ( const auto & row : collection_ )
-                { 
+                {
                     row.Content(fileStream);
                 }
             }

--- a/include/IO/Statistics/DtpRuntimeRow.hpp
+++ b/include/IO/Statistics/DtpRuntimeRow.hpp
@@ -23,7 +23,7 @@ namespace egoa::IO {
  * @see        egoa::DominatingThetaPath
  */
 class DtpRuntimeRow {
-    public: 
+    public:
         Types::string NameOfProblem;                /**< The name of the problem that is solved. */
         Types::name   Name;                         /**< The name of the instance. */
 
@@ -33,7 +33,7 @@ class DtpRuntimeRow {
         Types::count  NumberOfGenerators;           /**< The number of generators. */
         Types::count  NumberOfLoads;                /**< The number of loads. */
         Types::count  NumberOfEdges;                /**< The number of edges. */
-        
+
         Types::count  NumberOfEdgesProducingNoCycle;/**< The number of edges that produce not a cycle. */
         Types::count  NumberOfRelaxedEdges;         /**< The number of relaxed edges. */
         Types::count  NumberOfScannedEdges;         /**< The number of scanned edges. */
@@ -51,7 +51,7 @@ class DtpRuntimeRow {
             , NumberOfGenerators(0)
             , NumberOfLoads(0)
             , NumberOfEdges(0)
-            
+
             , NumberOfEdgesProducingNoCycle(0)
             , NumberOfRelaxedEdges(0)
             , NumberOfScannedEdges(0)
@@ -75,38 +75,38 @@ class DtpRuntimeRow {
             NumberOfLabels = 0;
         }
 
-        inline static void Header ( std::ostream & os ) 
+        inline static void Header ( std::ostream & os )
         {
             os
-                << "NameOfProblem"              << ",\t" 
+                << "NameOfProblem"              << ",\t"
                 << "Name"                       << ",\t"
 
                 << "SourceId"                   << ",\t"
-                
+
                 << "NumberOfVertices"           << ",\t"
                 << "NumberOfGenerators"         << ",\t"
                 << "NumberOfLoads"              << ",\t"
                 << "NumberOfEdges"              << ",\t"
 
-                << "NumberOfScannedEdges"       << ",\t" 
-                << "NumberOfEdgesProducingNoCycle"<< ",\t" 
-                << "NumberOfRelaxedEdges"       << ",\t" 
-                
-                << "NumberOfLabels"             << ",\t" 
+                << "NumberOfScannedEdges"       << ",\t"
+                << "NumberOfEdgesProducingNoCycle"<< ",\t"
+                << "NumberOfRelaxedEdges"       << ",\t"
+
+                << "NumberOfLabels"             << ",\t"
 
                 << "GlobalElapsedMilliseconds"  << ",\t"
 
-                << "\n";  
+                << "\n";
         }
 
-        inline void Content ( std::ostream & os ) const 
+        inline void Content ( std::ostream & os ) const
         {
-            os 
+            os
                 << NameOfProblem                << ",\t"
                 << Name                         << ",\t"
 
                 << SourceId                     << ",\t"
-                
+
                 << NumberOfVertices             << ",\t"
                 << NumberOfGenerators           << ",\t"
                 << NumberOfLoads                << ",\t"
@@ -115,7 +115,7 @@ class DtpRuntimeRow {
                 << NumberOfScannedEdges         << ",\t"
                 << NumberOfEdgesProducingNoCycle<< ",\t"
                 << NumberOfRelaxedEdges         << ",\t"
-                
+
                 << NumberOfLabels               << ",\t"
 
                 << GlobalElapsedMilliseconds
@@ -123,7 +123,7 @@ class DtpRuntimeRow {
                 << "\n";
         }
 
-        inline DtpRuntimeRow & operator+= ( const DtpRuntimeRow & rhs ) 
+        inline DtpRuntimeRow & operator+= ( const DtpRuntimeRow & rhs )
         {
             NumberOfEdgesProducingNoCycle   += rhs.NumberOfEdgesProducingNoCycle;
             NumberOfRelaxedEdges            += rhs.NumberOfRelaxedEdges;
@@ -143,7 +143,7 @@ class DtpRuntimeRow {
         }
 
         inline void WriteRowToFileWith ( Types::string const filename
-                                       , bool                overwrite = false ) 
+                                       , bool                overwrite = false )
         {
 #ifndef NDEBUG
             std::cout << "Write DTP runtime information row to: " << filename << std::endl;
@@ -156,14 +156,14 @@ class DtpRuntimeRow {
 
             // file is empty
             fileStream.seekp(0, std::ios::end);
-            if ( fileStream.tellp() == 0 ) 
-            { 
-                DtpRuntimeRow::Header(fileStream); 
+            if ( fileStream.tellp() == 0 )
+            {
+                DtpRuntimeRow::Header(fileStream);
             }
 
             fileStream << *this;
         }
-}; 
+};
 
 } // namespace egoa::IO
 

--- a/include/IO/Statistics/DtpRuntimeRow.hpp
+++ b/include/IO/Statistics/DtpRuntimeRow.hpp
@@ -1,0 +1,170 @@
+/*
+ * DtpRuntimeRow.hpp
+ *
+ *  Created on: Feb 03, 2019
+ *      Author: Franziska Wegner
+ */
+
+#ifndef EGOA__IO__STATISTICS__DTP_RUNTIME_ROW_HPP
+#define EGOA__IO__STATISTICS__DTP_RUNTIME_ROW_HPP
+
+#include <fstream>
+#include <iostream>
+#include <vector>
+
+#include "Auxiliary/Constants.hpp"
+#include "Auxiliary/Types.hpp"
+
+namespace egoa::IO {
+
+/**
+ * @brief      Statistics about one execution of the DTP algorithm.
+ *
+ * @see        egoa::DominatingThetaPath
+ */
+class DtpRuntimeRow {
+    public: 
+        Types::string NameOfProblem;                /**< The name of the problem that is solved. */
+        Types::name   Name;                         /**< The name of the instance. */
+
+        Types::vertexId  SourceId;                  /**< The source identifier. */
+
+        Types::count  NumberOfVertices;             /**< The number of vertices. */
+        Types::count  NumberOfGenerators;           /**< The number of generators. */
+        Types::count  NumberOfLoads;                /**< The number of loads. */
+        Types::count  NumberOfEdges;                /**< The number of edges. */
+        
+        Types::count  NumberOfEdgesProducingNoCycle;/**< The number of edges that produce not a cycle. */
+        Types::count  NumberOfRelaxedEdges;         /**< The number of relaxed edges. */
+        Types::count  NumberOfScannedEdges;         /**< The number of scanned edges. */
+        Types::count  NumberOfLabels;               /**< The number of labels. */
+
+        Types::real   GlobalElapsedMilliseconds;    /**< The total runtime. */
+
+        DtpRuntimeRow() :
+            NameOfProblem("DTP")
+            , Name("")
+
+            , SourceId(0)
+
+            , NumberOfVertices(0)
+            , NumberOfGenerators(0)
+            , NumberOfLoads(0)
+            , NumberOfEdges(0)
+            
+            , NumberOfEdgesProducingNoCycle(0)
+            , NumberOfRelaxedEdges(0)
+            , NumberOfScannedEdges(0)
+            , NumberOfLabels(0)
+
+            , GlobalElapsedMilliseconds(0.0)
+            {}
+
+        inline void Clear () {
+            NameOfProblem = "DTP";
+            Name = "";
+            SourceId = 0;
+            NumberOfVertices = 0;
+            NumberOfGenerators = 0;
+            NumberOfLoads = 0;
+            NumberOfEdges = 0;
+            NumberOfScannedEdges = 0;
+            NumberOfEdgesProducingNoCycle = 0;
+            NumberOfRelaxedEdges = 0;
+            GlobalElapsedMilliseconds = 0;
+            NumberOfLabels = 0;
+        }
+
+        inline static void Header ( std::ostream & os ) 
+        {
+            os
+                << "NameOfProblem"              << ",\t" 
+                << "Name"                       << ",\t"
+
+                << "SourceId"                   << ",\t"
+                
+                << "NumberOfVertices"           << ",\t"
+                << "NumberOfGenerators"         << ",\t"
+                << "NumberOfLoads"              << ",\t"
+                << "NumberOfEdges"              << ",\t"
+
+                << "NumberOfScannedEdges"       << ",\t" 
+                << "NumberOfEdgesProducingNoCycle"<< ",\t" 
+                << "NumberOfRelaxedEdges"       << ",\t" 
+                
+                << "NumberOfLabels"             << ",\t" 
+
+                << "GlobalElapsedMilliseconds"  << ",\t"
+
+                << "\n";  
+        }
+
+        inline void Content ( std::ostream & os ) const 
+        {
+            os 
+                << NameOfProblem                << ",\t"
+                << Name                         << ",\t"
+
+                << SourceId                     << ",\t"
+                
+                << NumberOfVertices             << ",\t"
+                << NumberOfGenerators           << ",\t"
+                << NumberOfLoads                << ",\t"
+                << NumberOfEdges                << ",\t"
+
+                << NumberOfScannedEdges         << ",\t"
+                << NumberOfEdgesProducingNoCycle<< ",\t"
+                << NumberOfRelaxedEdges         << ",\t"
+                
+                << NumberOfLabels               << ",\t"
+
+                << GlobalElapsedMilliseconds
+
+                << "\n";
+        }
+
+        inline DtpRuntimeRow & operator+= ( const DtpRuntimeRow & rhs ) 
+        {
+            NumberOfEdgesProducingNoCycle   += rhs.NumberOfEdgesProducingNoCycle;
+            NumberOfRelaxedEdges            += rhs.NumberOfRelaxedEdges;
+            NumberOfScannedEdges            += rhs.NumberOfScannedEdges;
+            NumberOfLabels                  += rhs.NumberOfLabels;
+
+            GlobalElapsedMilliseconds       += rhs.GlobalElapsedMilliseconds;
+
+            return *this;
+        }
+
+        friend std::ostream & operator<< ( std::ostream  & os
+                                         , DtpRuntimeRow & dtpRuntimeRow )
+        {
+            dtpRuntimeRow.Content ( os );
+            return os;
+        }
+
+        inline void WriteRowToFileWith ( Types::string const filename
+                                       , bool                overwrite = false ) 
+        {
+#ifndef NDEBUG
+            std::cout << "Write DTP runtime information row to: " << filename << std::endl;
+#endif
+            // Open output stream.
+            // ofstream fileStream(filename);
+            std::ofstream fileStream;
+            overwrite?fileStream.open(filename, std::ofstream::trunc):fileStream.open(filename, std::ofstream::app);
+            if (!fileStream.is_open()) return;
+
+            // file is empty
+            fileStream.seekp(0, std::ios::end);
+            if ( fileStream.tellp() == 0 ) 
+            { 
+                DtpRuntimeRow::Header(fileStream); 
+            }
+
+            fileStream << *this;
+        }
+}; 
+
+} // namespace egoa::IO
+
+#endif // EGOA__IO__STATISTICS__DTP_RUNTIME_ROW_HPP


### PR DESCRIPTION
This PR adds the DTP specific runtime row and collection to the framework. This is used for post analysis of the algorithm and plotting the results accordingly.

Each row captures 
* Name of the Problem,
* Name,
* Source Id,
* Number of Vertices,
* Number of Generators,
* Number of Loads,
* Number of Edges,
* Number of Scanned Edges,
* Number of Edges Producing No Cycle,
* Number of Relaxed Edges,
* Number of Labels,
* Global Elapsed Milliseconds.
