### PR TITLE
Add Local Standard Configuration to Run the Experiments

### DIFF
--- a/evaluations/2018_ACM_The-Maximum-Transmission-Switching-Flow-Problem/experiments/Configurations/localStdConfig.sh
+++ b/evaluations/2018_ACM_The-Maximum-Transmission-Switching-Flow-Problem/experiments/Configurations/localStdConfig.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+#
+# localConfig.sh
+#
+#   Created on:
+#       Author: Franziska Wegner
+#
+# Project configuration on the local computer to avoid long command line text
+# with arguments.
+#
+#########################################################
+# Define local standard argument ########################
+#########################################################
+
+EGOA_ALGORITHM="DCMTSF"
+EGOA_DIR_PATH_BENCHMARK_DATA="/Users/franziska-wegner/Documents/work/frameworks/egoa/data/PowerGrids/IEEEcases/11-NESTA/nesta-0.7.0/opf"
+EGOA_DIR_PATH_OUTPUT="/Users/franziska-wegner/Documents/work/frameworks/egoa/output"
+EGOA_FILE_PATH_EXECUTABLE="/Users/franziska-wegner/Documents/work/frameworks/egoa/.build/bin/egoa"
+
+# Maximum execution time of the algorithm
+EGOA_MAXIMUM_EXECUTION_TIME="0"
+# Track solutions over time (e.g., MILP solver via callbacks)
+EGOA_TRACK_SOLUTIONS="TRUE"
+# Number of parallel program executions (compute/server dependent)
+EGOA_NUM_PARALLEL_EXECUTIONS="40"
+# Number of parallel processes each execution of the algorithm gets (dependent
+# on the evaluation)
+EGOA_NUM_PARALLEL_PROCESSES="1"
+
+# Clean output directory
+EGOA_CLEAN_OUTPUT_DIR="TRUE"


### PR DESCRIPTION
This PR adds the local standard configuration to run the experiments for the publication "The Maximum Transmission Switching Flow Problem" (2018, ACM e-Energy) [[1]](http://dx.doi.org/10.1145/3208903.3208910). The project configuration on the local computer is used to avoid long command line text with arguments, to avoid mistakes, and improve on the reproducibility. 

**Changes to be committed:**
	new file:   evaluations/2018_ACM_The-Maximum-Transmission-Switching-Flow-Problem/experiments/Configurations/localStdConfig.sh

**Publication:**
[1] The Maximum Transmission Switching Flow Problem, ACM e-Energy, 2018, [doi:10.1145/3208903.3208910](http://dx.doi.org/10.1145/3208903.3208910). 
