### PR TITLE
Add Server Standard Configuration to Run the Experiments

### DIFF
--- a/evaluations/2018_ACM_The-Maximum-Transmission-Switching-Flow-Problem/experiments/Configurations/serverStdConfig.sh
+++ b/evaluations/2018_ACM_The-Maximum-Transmission-Switching-Flow-Problem/experiments/Configurations/serverStdConfig.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+#
+# serverConfig.sh
+# 
+#   Created on: Jan 30, 2019
+#       Author: Franziska Wegner
+#       
+# Project configuration on the server to avoid long command line text with
+# arguments.
+# 
+#########################################################
+# Define server standard argument ########################
+#########################################################
+
+EGOA_ALGORITHM="DCMTSF"
+EGOA_DIR_PATH_BENCHMARK_DATA=""
+EGOA_DIR_PATH_OUTPUT=""
+EGOA_FILE_PATH_EXECUTABLE=""
+EGOA_EXECUTABLE_NAME="egoa"
+
+# Maximum execution time of the algorithm
+EGOA_MAXIMUM_EXECUTION_TIME="0"
+# Track solutions over time (e.g., MILP solver via callbacks)
+EGOA_TRACK_SOLUTIONS="TRUE"
+# Number of parallel program executions (compute/server dependent)
+EGOA_NUM_PARALLEL_EXECUTIONS="40"
+# Number of parallel processes each execution of the algorithm gets (dependent
+# on the evaluation)
+EGOA_NUM_PARALLEL_PROCESSES="1"
+
+# Clean output directory
+EGOA_CLEAN_OUTPUT_DIR="TRUE"


### PR DESCRIPTION
This is mainly a copy of PR https://github.com/franziska-wegner/egoa/pull/86 to have the server paths separated from the local paths. This PR adds the server standard configuration to run the experiments for the publication "The Maximum Transmission Switching Flow Problem" (2018, ACM e-Energy) [[1]](http://dx.doi.org/10.1145/3208903.3208910). The project configuration on the local computer is used to avoid long command line text with arguments, to avoid mistakes, and improve on the reproducibility.

**Changes to be committed:**
	new file:   evaluations/2018_ACM_The-Maximum-Transmission-Switching-Flow-Problem/experiments/Configurations/serverStdConfig.sh

**Publication:**
[1] The Maximum Transmission Switching Flow Problem, ACM e-Energy, 2018, [doi:10.1145/3208903.3208910](http://dx.doi.org/10.1145/3208903.3208910).

