### PR TITLE
Add Git Commit Message Template to the Repository

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,9 @@
+# Include this file in your workflow with `git config --local include.path ./.gitconfig`
+[commit]
+        gpgsign = true
+        template = ./.gitmessage
+[filter "lfs"]
+        clean = git-lfs clean -- %f
+        smudge = git-lfs smudge -- %f
+        process = git-lfs filter-process
+        required = true

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,24 @@
+Title of the commit message
+
+##################################
+Why:
+## Why is the change necessary?
+## What does the reviewer of my put request expect in the commit, help them to easily identify and point out unrelated changes!
+
+* ...
+
+##################################
+This change addresses the need by:
+## How does it address the issue? Like performance improvements, or bugs, or ... <if change is obvious omit this part>
+
+* ...
+
+##################################
+What side effects does this change have?
+## To many points here means a to large commit! (1 or 2 is fine)
+
+* ...
+
+# 50-character subject line
+#
+# 72-character wrapped longer description.


### PR DESCRIPTION
This PR introduces a common commit message template that should be used for this repository. The questions help in identifying major problems with the commit beforehand and help in the aftermath to understand certain decision years after the commit if necessary. The repository dependent `.gitconfig` needs to be included with `git config --local include.path ./.gitconfig` to make this work.

The resources of the message are given in [1-5].

The template in [6] appears to me also very useful as well as the description of [7]. The latter describes the usage of multiple templates that are use case dependent, if I understand it correctly.

```
> vi ~./gitconfig:
	[commit]
        template = ./egoa/.gitmessage
```

**Changes to be committed:**
* new file:   .gitmessage
* new file:   .gitconfig

**Literature**
[1] https://thoughtbot.com/blog/better-commit-messages-with-a-gitmessage-template
[2] https://thoughtbot.com/blog/5-useful-tips-for-a-better-commit-message
[3] https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
[4] https://www.youtube.com/watch?v=PJjmw9TRB7s
[5] https://www.amazon.com/gp/product/B07MNKZJR9/ref=as_li_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=B07MNKZJR9&linkCode=as2&tag=initialcommit-20&linkId=21a8f51af6f217c290a950ce506fba59
[6] https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/
[7] https://learn.microsoft.com/en-us/azure/devops/repos/git/pull-request-templates?view=azure-devops