### PR TITLE
Remove Warnings Modernize Use of `auto`

### DIFF
--- a/tests/DataStructures/Graphs/TestGraph.cpp
+++ b/tests/DataStructures/Graphs/TestGraph.cpp
@@ -1612,7 +1612,7 @@ TYPED_TEST( TestGraphFourVertices, AddEdge) {
     }
 
     // Add edge (0,1)
-    TEdgeProperties edgeProperties01 = TEdgeProperties(0);
+    auto edgeProperties01 = TEdgeProperties(0);
     Types::edgeId source = 0;
     Types::edgeId target = 1;
     Types::edgeId id01   = this->graph_.AddEdge(source, target, edgeProperties01);
@@ -1635,7 +1635,7 @@ TYPED_TEST( TestGraphFourVertices, AddEdge) {
 
 
     // Add edge (1,2)
-    TEdgeProperties edgeProperties12 = TEdgeProperties(1);
+    auto edgeProperties12 = TEdgeProperties(1);
     source = 1;
     target = 2;
     Types::edgeId id12 = this->graph_.AddEdge(source, target, edgeProperties12);
@@ -1659,7 +1659,7 @@ TYPED_TEST( TestGraphFourVertices, AddEdge) {
 
 
     // Add edge (0,3)
-    TEdgeProperties edgeProperties03 = TEdgeProperties(2);
+    auto edgeProperties03 = TEdgeProperties(2);
     source = 0;
     target = 3;
     Types::edgeId id03 = this->graph_.AddEdge(source, target, edgeProperties03);

--- a/tests/DataStructures/Graphs/TestPowerGrid.cpp
+++ b/tests/DataStructures/Graphs/TestPowerGrid.cpp
@@ -3223,7 +3223,7 @@ TEST_F  ( TestPowerGridAcm2018MtsfFigure4a
 TEST_F  ( TestPowerGridAcm2018MtsfFigure4a
         , AddLoadAtUsingVertexId )
 {
-    Types::vertexId vertexId = static_cast<Types::vertexId>(2);
+    auto vertexId = static_cast<Types::vertexId>(2);
     EXPECT_EQ    ( 1, network_.NumberOfLoads() );
     EXPECT_FALSE ( network_.HasLoadAt ( vertexId ) );
     // Add load at vertex 2
@@ -3241,7 +3241,7 @@ TEST_F  ( TestPowerGridAcm2018MtsfFigure4a
 TEST_F  ( TestPowerGridAcm2018MtsfFigure4b
         , AddLoadAtUsingVertexId )
 {
-    Types::vertexId vertexId = static_cast<Types::vertexId>(1);
+    auto vertexId = static_cast<Types::vertexId>(1);
     EXPECT_EQ    ( 1, network_.NumberOfLoads() );
     EXPECT_FALSE ( network_.HasLoadAt ( vertexId ) );
     // Add load at vertex 2
@@ -4774,7 +4774,7 @@ TEST_F  ( TestNetworkEmpty
                 << assertionString;
     }
 
-    Types::generatorId generatorId = static_cast<Types::generatorId>(0);
+    auto generatorId = static_cast<Types::generatorId>(0);
     assertionString = buildAssertionString ( "PowerGrid.hpp"
                                            , "PowerGrid"
                                            , "AddGeneratorRealPowerSnapshotAt"
@@ -4966,7 +4966,7 @@ TEST_F  ( TestNetworkEmpty
                 << assertionString;
     }
 
-    Types::loadId loadId = static_cast<Types::loadId>(0);
+    auto loadId = static_cast<Types::loadId>(0);
     assertionString = buildAssertionString ( "PowerGrid.hpp"
                                            , "PowerGrid"
                                            , "AddLoadSnapshotAt"


### PR DESCRIPTION
Apply modernize use of auto in `TestPowerGrid.cpp` and `TestGraph.cpp`. The use of `auto` is preferred when initializing with a cast to avoid duplicating the type name.

<img width="1265" alt="Screenshot 2024-01-05 at 10 55 16 AM" src="https://github.com/franziska-wegner/egoa/assets/57569315/5722a830-6c65-4746-b48e-162bd581ef42">
<img width="1282" alt="Screenshot 2024-01-05 at 10 55 43 AM" src="https://github.com/franziska-wegner/egoa/assets/57569315/d0f4e8b2-48d1-4ce1-af3a-a29bd0a5a9ca">

