### PR TITLE
Remove some Compiler Warnings to prepare for Pedantic Mode

### DIFF
--- a/include/IO/Appearance/Color.hpp
+++ b/include/IO/Appearance/Color.hpp
@@ -279,15 +279,15 @@ class Color {
         ~Color(){}
 
 
-        bool operator== ( const Color& rhs ) {
+        bool operator== ( Color const  & rhs ) {
             return Red() == rhs.Red() && Green() == rhs.Green() && Blue() == rhs.Blue();
         }
 
-        bool operator!= ( const Color& rhs ) {
+        bool operator!= ( Color const & rhs ) {
             return !operator==(rhs);
         }
 
-        friend std::ostream& operator<<(std::ostream& os, const Name color ) {
+        friend std::ostream& operator<<(std::ostream& os, Name const color ) {
             switch ( color ) {
                 case Name::KITgreen:      os << "KITgreen";   break;
                 case Name::KITgreen70:    os << "KITgreen70"; break;

--- a/src/Runnables/main.cpp
+++ b/src/Runnables/main.cpp
@@ -208,7 +208,7 @@ void setNetworkSetting(egoa::PowerGrid<TGraph> & network, const QString & networ
     else if ( networkSetting == "EXACT"        ) { network.MakeExact();         }
 }
 
-int main(int argc, char *argv[]) {
+void main(int const argc, char const * const * const argv) -> int {
 
 // Command line parsing
     auto application = std::unique_ptr<QCoreApplication>(std::make_unique<QCoreApplication>(argc, argv));

--- a/src/Runnables/main.cpp
+++ b/src/Runnables/main.cpp
@@ -208,7 +208,7 @@ void setNetworkSetting(egoa::PowerGrid<TGraph> & network, const QString & networ
     else if ( networkSetting == "EXACT"        ) { network.MakeExact();         }
 }
 
-void main(int const argc, char const * const * const argv) -> int {
+auto main(int const argc, char const * const * const argv) -> int {
 
 // Command line parsing
     auto application = std::unique_ptr<QCoreApplication>(std::make_unique<QCoreApplication>(argc, argv));

--- a/src/Runnables/main.cpp
+++ b/src/Runnables/main.cpp
@@ -208,7 +208,7 @@ void setNetworkSetting(egoa::PowerGrid<TGraph> & network, const QString & networ
     else if ( networkSetting == "EXACT"        ) { network.MakeExact();         }
 }
 
-auto main(int const argc, char const * const * const argv) -> int {
+auto main(int argc, char * argv []) -> int {
 
 // Command line parsing
     auto application = std::unique_ptr<QCoreApplication>(std::make_unique<QCoreApplication>(argc, argv));

--- a/tests/DataStructures/Container/TestMappingBinaryHeap.cpp
+++ b/tests/DataStructures/Container/TestMappingBinaryHeap.cpp
@@ -13,7 +13,7 @@ using ::testing::MatchesRegex;
 
 namespace egoa::test {
 
-std::string buildAssertionString(std::string function, std::string message) {
+auto buildAssertionString(std::string const & function, std::string const & message) -> std::string {
     return buildAssertionString("MappingBinaryHeap.hpp", "MappingBinaryHeap", function, message);
 }
 

--- a/tests/DataStructures/Graphs/TestPowerGrid.cpp
+++ b/tests/DataStructures/Graphs/TestPowerGrid.cpp
@@ -3223,12 +3223,12 @@ TEST_F  ( TestPowerGridAcm2018MtsfFigure4a
 TEST_F  ( TestPowerGridAcm2018MtsfFigure4a
         , AddLoadAtUsingVertexId )
 {
-    auto vertexId = static_cast<Types::vertexId>(2);
+    auto const vertexId = static_cast<Types::vertexId>(2);
     EXPECT_EQ    ( 1, network_.NumberOfLoads() );
     EXPECT_FALSE ( network_.HasLoadAt ( vertexId ) );
     // Add load at vertex 2
     TLoadProperties loadProperties;
-    Types::loadId   loadId   = network_.AddLoadAt ( vertexId, loadProperties );
+    Types::loadId const loadId = network_.AddLoadAt ( vertexId, loadProperties );
     // Check
     EXPECT_TRUE  ( network_.HasLoadAt ( vertexId ) );
     EXPECT_TRUE  ( network_.HasLoad   ( loadId   ) );

--- a/tests/DataStructures/TestBound.cpp
+++ b/tests/DataStructures/TestBound.cpp
@@ -18,9 +18,9 @@ using ::testing::Le;
 
 namespace egoa::test {
 
-TestBound::TestBound () {}
+TestBound::TestBound () = default;
 
-TestBound::~TestBound () {}
+TestBound::~TestBound () = default;
 
 void TestBound::SetUp () {}
 


### PR DESCRIPTION
This PR is part of the warning awareness week as we soon will switch to pedantic compilation mode to avoid unnecessary conflicts for all developers from the "beginning".