### PR TITLE
Add `gen_tables.sh` used for "The Maximum Transmission Switching Flow Problem"

### DIFF
--- a/evaluations/2018_ACM_The-Maximum-Transmission-Switching-Flow-Problem/statistics/gen_tables.sh
+++ b/evaluations/2018_ACM_The-Maximum-Transmission-Switching-Flow-Problem/statistics/gen_tables.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# gen_tables.sh
+#
+#   Created on: -
+#       Author: Franziska Wegner
+#
+# Generates the short and long tables that are used in the paper
+# "The Maximum Transmission Switching Flow Problem", 2018, ACM e-Energy,
+# doi:10.1145/3208903.3208910.
+#
+
+/Users/fwegner/anaconda/bin/Rscript ./table_models_algorithms.R $PATH "tbl:MTSF_MPF_PF_MF_long" "TRUE" "FALSE" >$OUTPUT/tbl-milp-comparison-long.tex
+#........................................................................................................./\
+#.......................................................................................................Short?
+#.........................................................................................................\/
+/Users/fwegner/anaconda/bin/Rscript ./table_models_algorithms.R $PATH "tbl:MTSF_MPF_PF_MF_short" "TRUE" "TRUE" >$OUTPUT/tbl-milp-comparison-short.tex
+
+# ---------------------------------------------------------------------------
+# Replace strings
+# ---------------------------------------------------------------------------
+/usr/bin/sed -i -- 's/\$\\backslash\$/\\/g' $OUTPUT/*
+/usr/bin/sed -i -- 's/\\{/{/g' $OUTPUT/*
+/usr/bin/sed -i -- 's/\\}/}/g' $OUTPUT/*
+/bin/rm -f $OUTPUT/*.tex-*


### PR DESCRIPTION
Generates the short and long tables that are used in the paper [1].

**Publication:**
[1] "The Maximum Transmission Switching Flow Problem", 2018, ACM e-Energy, [doi:10.1145/3208903.3208910](http://dx.doi.org/10.1145/3208903.3208910).

**Changes to be committed:**
* new file: `evaluations/2018_ACM_The-Maximum-Transmission-Switching-Flow-Problem/statistics/gen_tables.sh`


<img width="1272" alt="Screenshot 2024-01-09 at 1 57 15 AM" src="https://github.com/franziska-wegner/egoa/assets/57569315/3da9dfd2-a2e7-4806-a748-a7882f2d998f">
